### PR TITLE
Fixes for Virtex7 partial reconfiguration

### DIFF
--- a/src/torc/bitstream/Virtex7.cpp
+++ b/src/torc/bitstream/Virtex7.cpp
@@ -1142,8 +1142,8 @@ namespace bitstream{
 		//	Packets marked S pertain to shutdown bitstreams only
 		//	S	000008ed: TYPE1 WRITE CMD GRESTORE
 		//	S	000008f5: NOP x 1
-		//		000008f9: TYPE1 WRITE CMD DGHIGH/LFRM
-		//		00000901: NOP x 100
+		//	S   000008f9: TYPE1 WRITE CMD DGHIGH/LFRM
+		//	S	00000901: NOP x 100
 		//	S	00000a91: TYPE1 WRITE CMD GRESTORE
 		//	S	00000a99: NOP x 1
 		//	S	00000a9d: TYPE1 WRITE CMD START
@@ -1162,12 +1162,9 @@ namespace bitstream{
 			// restore command
 			packets.push_back(VirtexPacket::makeType1Write(eRegisterCMD, eCommandGRESTORE));
 			packets.push_back(nop);
-		}
-		// last frame command
-		packets.push_back(VirtexPacket::makeType1Write(eRegisterCMD, eCommandLFRM));
-		packets.insert(packets.end(), 100, nop);
-		// extra for shutdown bitstreams
-		if(inBitstreamType == eBitstreamTypePartialShutdown) {
+            // last frame command
+            packets.push_back(VirtexPacket::makeType1Write(eRegisterCMD, eCommandLFRM));
+            packets.insert(packets.end(), 100, nop);
 			// restore command
 			packets.push_back(VirtexPacket::makeType1Write(eRegisterCMD, eCommandGRESTORE));
 			packets.push_back(nop);

--- a/src/torc/bitstream/Virtex7.cpp
+++ b/src/torc/bitstream/Virtex7.cpp
@@ -939,7 +939,7 @@ namespace bitstream{
 				makeSubfield(eRegisterCOR1, "BPI_page_size", "1") |
 			0));
 		// write the ID code
-		packets.push_back(VirtexPacket::makeType1Write(eRegisterIDCODE, 0x00000000));
+		packets.push_back(VirtexPacket::makeType1Write(eRegisterIDCODE, getIdCode()));
 		// clock and rate switch command
 		packets.push_back(VirtexPacket::makeType1Write(eRegisterCMD, eCommandSWITCH));
 		packets.push_back(nop);
@@ -1105,7 +1105,7 @@ namespace bitstream{
 		packets.push_back(nop);
 		packets.push_back(nop);
 		// write the ID code
-		packets.push_back(VirtexPacket::makeType1Write(eRegisterIDCODE, 0x00000000));
+		packets.push_back(VirtexPacket::makeType1Write(eRegisterIDCODE, getIdCode()));
 		// extra for shutdown bitstreams
 		if(inBitstreamType == eBitstreamTypePartialShutdown) {
 			// configuration options register 0

--- a/src/torc/bitstream/VirtexBitstream.cpp
+++ b/src/torc/bitstream/VirtexBitstream.cpp
@@ -132,8 +132,13 @@ namespace bitstream {
 		typename ARCH::iterator e = end();
 		while(p < e) {
 		    const VirtexPacket& packet = *p++;
+
+			// Read ID Code
+			if(packet.isWrite() && packet.getAddress() == ARCH::eRegisterIDCODE && packet.getWordCount() == 1) {
+				mIdCode = packet[1];
+			}
 			// process FAR write packets
-			if(packet.isWrite() && packet.getAddress() == ARCH::eRegisterFAR) {
+			else if(packet.isWrite() && packet.getAddress() == ARCH::eRegisterFAR) {
 				// extract the new frame address
 				frameAddress = typename ARCH::FrameAddress(packet[1]);
 				// convert the frame address to the corresponding frame index

--- a/src/torc/bitstream/VirtexBitstream.cpp
+++ b/src/torc/bitstream/VirtexBitstream.cpp
@@ -383,12 +383,6 @@ namespace bitstream {
 		VirtexPacketVector packets;
 		VirtexPacket nop(VirtexPacket::makeHeader(ePacketType1, eOpcodeNOP, 0, 0));
 
-		// write the starting frame address
-		packets.push_back(VirtexPacket::makeType1Write(ARCH::eRegisterFAR, 0));
-		// write the write configuration register command
-		packets.push_back(VirtexPacket::makeType1Write(ARCH::eRegisterCMD, ARCH::eCommandWCFG));
-		packets.push_back(nop);
-
 		// iterate through the frame blocks looking for groups of contiguous frames that are in use
 		bool empty = true;
 		uint32_t index = 0;
@@ -450,6 +444,9 @@ namespace bitstream {
 						else do { *pos++ = 0; wp++; } while(wp < we); // frames with no words
 						currentIndex++;
 					}
+                    // write the write configuration register command
+                    packets.push_back(VirtexPacket::makeType1Write(ARCH::eRegisterCMD, ARCH::eCommandWCFG));
+                    packets.push_back(nop);
 					// write the starting frame address
 					packets.push_back(VirtexPacket::makeType1Write(ARCH::eRegisterFAR, 
 						inFrameIndexToAddress[blockStart + startIndex]));

--- a/src/torc/bitstream/VirtexBitstream.hpp
+++ b/src/torc/bitstream/VirtexBitstream.hpp
@@ -63,11 +63,12 @@ namespace bitstream { class VirtexBitstreamUnitTest; }
 	// members
 		/// \brief Input Frame blocks.
 		VirtexFrameBlocks mFrameBlocks;
+		uint32_t mIdCode;
 	public:
 	// constructors
 		/// \brief Basic constructor.
 		VirtexBitstream(void) : Bitstream(), VirtexPacketVector(), VirtexPacketConstants(), 
-			VirtexFrameBlocks() {}
+			VirtexFrameBlocks(), mIdCode(0) {}
 	// functions
 		/// \brief Read bitstream packets from a stream.
 		/// \note This function should be called after the bitstream header has been read.
@@ -133,6 +134,9 @@ namespace bitstream { class VirtexBitstreamUnitTest; }
 		/// \brief Append the contents of a packet vector to the end of the bitstream.
 		void append(const VirtexPacketVector& inVector) {
 			VirtexPacketVector::insert(end(), inVector.begin(), inVector.end());
+		}
+		uint32_t getIdCode() {
+			return mIdCode;
 		}
 	// accessors
 		/// \brief Return the configuration frame blocks.


### PR DESCRIPTION
Hi, I have identified several problems with Virtex 7 partial reconfiguration bitstreams:

- IDCODE is always zero, so the device will reject the bitstream
- LFRM is included even in active bitstreams where it is not needed
- FAR is always written to zero at the beginning of the partial bitstream even when the first frame is on a different address